### PR TITLE
Sync historical adherence incrementally, catch exceptions in thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ get_catalog.py
 out.json
 tap_purecloud.egg-info/
 state.json
+logs/
+out.log
+run.sh

--- a/tap_purecloud/context.py
+++ b/tap_purecloud/context.py
@@ -1,0 +1,31 @@
+import singer
+from singer import bookmarks as bks_
+
+
+class Context(object):
+    """Represents a collection of global objects necessary for performing
+    discovery or for running syncs. Notably, it contains
+
+    - state   - The mutable state dict that is shared among streams
+    """
+    def __init__(self, state):
+        self.state = state
+
+    def get_bookmark(self, path):
+        return bks_.get_bookmark(self.state, *path)
+
+    def set_bookmark(self, path, val):
+        bks_.write_bookmark(self.state, path[0], path[1], val)
+
+    def get_offset(self, path):
+        off = bks_.get_offset(self.state, path[0])
+        return (off or {}).get(path[1])
+
+    def set_offset(self, path, val):
+        bks_.set_offset(self.state, path[0], path[1], val)
+
+    def clear_offsets(self, tap_stream_id):
+        bks_.clear_offset(self.state, tap_stream_id)
+
+    def write_state(self):
+        singer.write_state(self.state)


### PR DESCRIPTION
This PR makes the purecloud tap use bookmarks to incrementally sync historical adherence for management units. This means that very long first-time syncs which fail due to unfortunate network/api blips can resume syncing from where they leave off. Further, an attempt was made to catch and retry when specific types of network blips are encountered.